### PR TITLE
Restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ const maxY = await element.on("mousemove")
 ### Synchronous delivery
 
 Event delivery with Observables is synchronous, unlike Promises which queue
-microtasks to invoke callbacks.
-
-This [example](https://github.com/whatwg/dom/issues/544#issuecomment-351758385)
-demonstrates synchronous event delivery:
+microtasks when invoking callbacks. Consider this
+[example](https://github.com/whatwg/dom/issues/544#issuecomment-351758385):
 
 ```js
 el.on('click').subscribe(() => console.log('One'));


### PR DESCRIPTION
This closes #5 which gives some great feedback on the explainer structure. This PR is mostly limited to restructuring the explainer, while it fills out a tiny bit of some of the sections. But most of the previously-unfinished content is still unfinished, and will be fleshed out in subsequent PRs.