### PR TITLE
Capitalize on promise analogy and `EventTarget` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ https://github.com/whatwg/dom/issues/544#issuecomment-631402455
 
 ## Background
 
-They are "lazy" in that they do not emit data until they are subscribed to,
-push-based in that the producer of data decides when the consumer receives it,
-and temporal in that they can push arbitrary amounts of data at any time.
+Observables are "lazy" in that they do not emit data until they are subscribed
+to, push-based in that the producer of data decides when the consumer receives
+it, and temporal in that they can push arbitrary amounts of data at any time.
 
 To illustrate of how producers and consumers interact with Observables compared
 to other primitives, see the below table, which is an attempt at combining


### PR DESCRIPTION
This PR closes https://github.com/domfarolino/observable/issues/10, by drawing direct analogies with Promises in the section immediately following the [`EventTarget` integration](https://github.com/domfarolino/observable#eventtarget-integration), which is the first section that has real explanatory text about what an Observable is.

A subsequent PR will address https://github.com/domfarolino/observable/issues/6 by moving some of the other explanatory content (that's currently in the "Background" section) that describes how observables are lazy, synchronous, and "glorified functions" into the main Observable API section, and cleaned up.