### PR TITLE
Better explanation and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,16 @@ about having the Observable constructor being able to register teardown upon
 unsubscription.
 
 While custom Observables can be useful on their own, the primary use case we
-unlock with them is with event handling. Observables returned by the new
+unlock is with event handling. Observables returned by the new
 `EventTarget#on()` method are created natively with an internal callback that
 uses the same [underlying
 mechanism](https://dom.spec.whatwg.org/#add-an-event-listener) as
-`addEventListener()`. This means that calling `subscribe()` essentially
-registers a new event listener whose events are exposed through the `Observer`
-interface and are composable with the various
+`addEventListener()`. Therefore calling `subscribe()` essentially registers a
+new event listener whose events are exposed through the Observer handler
+functions and are composable with the various
 [combinators](#operators--combinators) available to all Observables.
+
+TODO: A simple example.
 
 ### Lazy, synchronous delivery
 


### PR DESCRIPTION
This should be enough to close https://github.com/domfarolino/observable/issues/6 by incorporating most of the feedback there into "The `Observable` API" section which is just below the EventTarget integration section which is basically just examples, but before the newly-renamed "Background & landscape" section.

We could probably still use some more examples but that can be tracked by #4. For now, this removes the "glorified function argument and discusses the real semantics and usage of the Observable interface, as well as its event target integration and synchronous (but lazy) delivery strategy.