### PR TITLE
Adds a multiplexed web socket example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,21 @@ function streamStock(ticker) {
   });
 }
 
+function finish(stopMsg) {
+  socket.send(JSON.stringify(stopMsg));
+}
+
 const googTrades = streamStock('GOOG');
 const nflxTrades = streamStock('NFLX');
 
-const googSubscription = googTrades.subscribe(updateView);
-const nflxSubscription = nflxTrades.subscribe(updateView);
+const googController = new AbortController();
+const googSubscription = googTrades.subscribe({next: updateView, signal: googController.signal});
+const nflxSubscription = nflxTrades.subscribe({next: updateView, ...});
 
 // And the stream can disconnect later, which
 // automatically sends the unsubscription message
 // to the server.
-googSubscription.unsubscribe();
+googController.abort();
 ```
 
 <details>


### PR DESCRIPTION
I'm proposing that we add this multiplexed web socket example. It's one of the cooler things you can do with the available APIs, assuming that we can land a `flatMap` and `finally` method.

That said, the "cooler" stuff would require leveraging the `new Observable` bit a lot more. Things like reconnection, etc.

Fixes #8, and makes progress on #4.