### PR TITLE
Remove redundant function declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,6 @@ function streamStock(ticker) {
   });
 }
 
-function finish(stopMsg) {
-  socket.send(JSON.stringify(stopMsg));
-}
-
 const googTrades = streamStock('GOOG');
 const nflxTrades = streamStock('NFLX');
 


### PR DESCRIPTION
The `finish` method in example 5 is unused. Removing it will make the example easier to quickly grok.