### PR TITLE
Fix `forEach` and `toArray` return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ interface Observable {
   Observable drop(unsigned long long);
   Observable flatMap(Function project);
   Promise<sequence<any>> toArray();
-  undefined forEach(Function callback);
+  Promise<undefined> forEach(Function callback);
 
   // Promise-returning. See "Concerns" section below.
   Promise<any> every(Predicate predicate);

--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ interface Observable {
   Observable take(unsigned long long);
   Observable drop(unsigned long long);
   Observable flatMap(Function project);
-  Observable toArray();
-  Observable forEach(Function callback);
+  Promise<sequence<any>> toArray();
+  undefined forEach(Function callback);
 
   // Promise-returning. See "Concerns" section below.
   Promise<any> every(Predicate predicate);


### PR DESCRIPTION
Closes #27. Per discussion there, it seems we've landed on:
 - `toArray()` causing a subscription, and asynchronously yielding an array via a Promise, which seems natural
 - `forEach()` per https://github.com/domfarolino/observable/issues/29#issuecomment-1656292907, this also causes a subscription, so it shouldn't return an `Observable`. And since there's no accumulated or passed-through values, it returns undefined.