### PR TITLE
Use more specific callback types

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ interface Subscriber {
 
 callback Predicate = boolean (any value);
 callback Reducer = any (any accumulator, any currentValue)
+callback Mapper = any (any element, unsigned long long index)
+// Differs from `Mapper` only in return type, since this callback is exclusively
+// used to visit each element in a sequence, not transform it.
+callback Visitor = undefined (any element, unsigned long long index)
 
 [Exposed=*]
 interface Observable {
@@ -322,15 +326,14 @@ interface Observable {
   undefined finally(VoidFunction callback);
 
   // Observable-returning operators. See "Operators" section below.
-  // TODO: Use more specific callback types than `Function`.
   Observable takeUntil(Observable notifier);
-  Observable map(Function project);
+  Observable map(Mapper mapper);
   Observable filter(Predicate predicate);
   Observable take(unsigned long long);
   Observable drop(unsigned long long);
-  Observable flatMap(Function project);
+  Observable flatMap(Mapper mapper);
   Promise<sequence<any>> toArray(optional PromiseOptions options);
-  Promise<undefined> forEach(Function callback, optional PromiseOptions options);
+  Promise<undefined> forEach(Visitor callback, optional PromiseOptions options);
 
   // Promise-returning. See "Concerns" section below.
   Promise<any> every(Predicate predicate, optional PromiseOptions options);


### PR DESCRIPTION
This PR satisfies the rest of #26. It uses more specific callback types for the following operators:
 - `map()`
 - `flatMap()`
 - `forEach()`

In particular, it uses the [unsigned long long](https://webidl.spec.whatwg.org/#idl-unsigned-long-long) WebIDL type to represent the "index" of the item being passed into the corresponding callback, since it is the largest _integer_ type that WebIDL is. At first I was worried about that, because that type has a max value of 2<sup>64</sup> - 1, which is strictly larger than ECMAScript's "Number" type, which appears to be used for the same "index" argument in the Iterator helpers (see [`map()`](https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map)) and AsyncIterator helpers (see [`map()`](https://tc39.es/proposal-async-iterator-helpers/#sec-asynciteratorprototype.map)). Specifically, ECMAScript calls 𝔽(counter) for each index that gets incremented, which [maps](https://tc39.es/ecma262/#%F0%9D%94%BD) the index to [a Number](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type), which is just a double (and smaller than an unsigned long long).

Fortunately, when WebIDL [converts an unsigned long long to an ECMAScript value](https://webidl.spec.whatwg.org/#ref-for-idl-unsigned-long-long%E2%91%A4), it does so in the exact same way that ECMAScript does (by choosing the closest ECMAScript "Number" value to the given value as possible, choosing the even even significand one when necessary).