### PR TITLE
`Observable.from()` & accept conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,17 @@ interface Observable {
 
   undefined finally(VoidFunction callback);
 
+  // Constructs a native Observable from `value` if it's any of the following:
+  //   - Observable
+  //   - Promise
+  //   - Iterable
+  //   - AsyncIterable
+  static Observable from(any value);
+
   // Observable-returning operators. See "Operators" section below.
-  Observable takeUntil(Observable notifier);
+  // `takeUntil()` can consume promises, iterables, async iterables, and other
+  // observables.
+  Observable takeUntil(any notifier);
   Observable map(Mapper mapper);
   Observable filter(Predicate predicate);
   Observable take(unsigned long long);
@@ -381,6 +390,21 @@ mechanism](https://dom.spec.whatwg.org/#add-an-event-listener) as
 new event listener whose events are exposed through the Observer handler
 functions and are composable with the various
 [combinators](#operators) available to all Observables.
+
+#### Constructing & converting objects to Observables
+
+Observables can be created by their native constructor, as demonstrated above,
+or by the `Observable.from()` static method. This method constructs a native
+Observable from any of the following objects:
+
+ - `Observable` (in which case it just returns the given object)
+ - `Promise` (or any thenable)
+ - `Iterable` (anything with `Symbol.iterator`)
+ - `AsyncIterable` (anything with `Symbol.asyncIterator`)
+
+Furthermore, any method on the platform that wishes to accept an `Observable`
+can take any of the above objects as well (by accepting a WebIDL `any`), which
+will be converted to a native Observable before being subscribed to.
 
 #### Lazy, synchronous delivery
 
@@ -452,7 +476,10 @@ methods](https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype) to
  - `some()`
  - `every()`
  - `find()`
- - maybe: `from()`
+
+And the following method statically on the `Iterator` constructor:
+
+ - `from()`
 
 We expect userland libraries to provide more niche operators that integrate with
 the `Observable` API central to this proposal, potentially shipping natively if

--- a/README.md
+++ b/README.md
@@ -413,7 +413,9 @@ ways that we'll finalize in the Observable specification:
     other types.
  2. Require methods and callbacks that work with Observables to specify the type
     `any`, and have the corresponding spec prose immediately invoke a conversion
-    algorithm that the Observable specification will supply.
+    algorithm that the Observable specification will supply. This is similar to
+    what the Streams Standard [does with async iterables
+    today](https://streams.spec.whatwg.org/#rs-from).
 
 The conversation in https://github.com/domfarolino/observable/pull/60 leans
 towards option (1).

--- a/README.md
+++ b/README.md
@@ -404,9 +404,9 @@ Observable from objects that are any of the following, _in this order_:
 
 Furthermore, any method on the platform that wishes to accept an Observable as a
 Web IDL argument, or return one from a callback whose return type is
-`Observable` can do so with any of the above objects as well. This can be
-accomplished in one of two ways that we'll finalize in the Observable
-specification:
+`Observable` can do so with any of the above objects as well, that get
+automatically converted to an Observable. We can accomplish this in one of two
+ways that we'll finalize in the Observable specification:
 
  1. By making the `Observable` type a special Web IDL type that performs this
     ECMAScript Object ➡️ Web IDL conversion automatically, like Web IDL does for

--- a/README.md
+++ b/README.md
@@ -402,9 +402,21 @@ Observable from objects that are any of the following, _in this order_:
  - `Iterable` (anything with `Symbol.iterator`)
  - `Promise` (or any thenable)
 
-Furthermore, any method on the platform that wishes to accept an `Observable`
-can take any of the above objects as well (by accepting a WebIDL `any`), which
-will be converted to a native Observable before being subscribed to.
+Furthermore, any method on the platform that wishes to accept an Observable as a
+Web IDL argument, or return one from a callback whose return type is
+`Observable` can do so with any of the above objects as well. This can be
+accomplished in one of two ways that we'll finalize in the Observable
+specification:
+
+ 1. By making the `Observable` type a special Web IDL type that performs this
+    ECMAScript Object ➡️ Web IDL conversion automatically, like Web IDL does for
+    other types.
+ 2. Require methods and callbacks that work with Observables to specify the type
+    `any`, and have the corresponding spec prose immediately invoke a conversion
+    algorithm that the Observable specification will supply.
+
+The conversation in https://github.com/domfarolino/observable/pull/60 leans
+towards option (1).
 
 #### Lazy, synchronous delivery
 

--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ interface Observable {
 
   // Constructs a native Observable from `value` if it's any of the following:
   //   - Observable
-  //   - Promise
-  //   - Iterable
   //   - AsyncIterable
+  //   - Iterable
+  //   - Promise
   static Observable from(any value);
 
   // Observable-returning operators. See "Operators" section below.
@@ -395,12 +395,12 @@ functions and are composable with the various
 
 Observables can be created by their native constructor, as demonstrated above,
 or by the `Observable.from()` static method. This method constructs a native
-Observable from any of the following objects:
+Observable from objects that are any of the following, _in this order_:
 
  - `Observable` (in which case it just returns the given object)
- - `Promise` (or any thenable)
- - `Iterable` (anything with `Symbol.iterator`)
  - `AsyncIterable` (anything with `Symbol.asyncIterator`)
+ - `Iterable` (anything with `Symbol.iterator`)
+ - `Promise` (or any thenable)
 
 Furthermore, any method on the platform that wishes to accept an `Observable`
 can take any of the above objects as well (by accepting a WebIDL `any`), which


### PR DESCRIPTION
This PR should close #28 and #44, by providing a static `Observable.from()` method, as well as changing `takeUntil()` — the only web platform method proposed here that takes "an Observable" — to accept the same kinds of objects that `Observable.from()` does.

I had some trouble initially writing this PR. For example: when used as an argument, WebIDL's `Promise<T>` type accepts native Promises as well as all thenables, I believe, which appears to be achieved by delegating to ECMAScript's laxness around thenables. As proposed in this repository, Observables are not part of the ECMAScript language, so they don't get special ES<->WebIDL conversion steps that we might be able to use to accept anything that:
 - Is an `Observable`; or
 - Is a `Promise<T>`; or
 - Has a non-null `Symbol.iterator`; or
 - Has a non-null `Symbol.asyncIterator` protocol

Given that, I was at least hoping we'd be able to supply some kind of nifty conversion algorithm to convert these kinds of types _to_ native Observables, that WebIDL itself could hook into so that any web platform methods that want to accept an Observable can just accept the `Observable` type itself (and the conversion will be done automatically as part of the bindings). Unfortunately I don't think that's possible, nor does it seem possible to express an async iterable type in WebIDL either. For example, https://github.com/whatwg/webidl/issues/874 seems to indicate that the best we can do is accept an `any` and then do the conversion manually by calling ES's `GetIterator(object, async)`, as the Streams Standard does here: https://streams.spec.whatwg.org/#readable-stream-from-iterable.

This isn't horrible, and it doesn't seem like a serious blocker or anything, but if Observables became widely used on the platform we'd be encouraging a bunch of `any` methods that have to delegate to some abstract conversion algorithm that our spec will add. We can always introduce syntax to WebIDL later to make it possible to express a type that is async iterable (something like `async sequence<T>` perhaps); this would allow us to use methods that accept a `typedef (Promise<T> or sequence<T> or async sequence<T>) ObservableInit` — except oh wait, Promises can't be used in unions! So I guess we're stuck with encouraging `any`...