### PR TITLE
Add `addTeardown()`. Closes #3. Closes #19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ If the subscriber has already been aborted (i.e., `subscriber.signal.aborted` is
  - From `complete()`, after the subscriber's complete handler (if any) is
    invoked
  - From `error()`, after the subscriber's error handler (if any) is invoked
+ - The signal passed to the subscription is aborted by the user.
 
 
 ### Operators


### PR DESCRIPTION
This PR clarifies the `addTeardown()` API, which is just syntactic sugar over responding accordingly to `Subscriber#signal`. I'm honestly not 100% sure if we need it, but it does seem like a nice first-class convenience API to get around the pesky is-this-signal-already-aborted check that would have to be made by ever subscriber with a clean-up function, at least until `AbortSignal` gets an API [like `whenAborted()`](https://github.com/domfarolino/observable/issues/19#issuecomment-1700309108).

My only concern here is that it might be confusing if we expose both `Subscriber#signal` _and_ `Subscriber#addTeardown()`, when you really only need one or the other. If we're going to have this first-class API, I kind of lean towards **not** exposing `Subscriber#signal` anymore, and pushing people to use `addTeardown()` exclusively, but what do you think @benlesh?