### PR TITLE
Reject reduce#complete with a RangeError in favor of TypeError

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1747,7 +1747,10 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        : [=internal observer/complete steps=]
        :: 1. If |accumulator| is not "<code>unset</code>", then [=resolve=] |p| with |accumulator|.
 
-          Otherwise, [=reject=] |p| with a {{TypeError}}.
+          Otherwise, [=reject=] |p| with a {{RangeError}}.
+
+          Note: This is only reached when the source {{Observable}} completes *before* it emits a
+          single value and no |initialValue| was passed in.
 
     1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
        and |internal options|.


### PR DESCRIPTION
What Im proposing to merge could swing either way, so opening this more up as a point of discussion and if we agree, lets merge.

For our [`first`](https://wicg.github.io/observable/#dom-observable-first) and [`last`](https://wicg.github.io/observable/#dom-observable-last) promise-returning operators, if there were no values produced by the time the `complete` handlers fire, we reject with a `RangeError`. But here, with [`reduce`](https://wicg.github.io/observable/#dom-observable-reduce) the spec wants a `TypeError`.

Should we keep consistency, and have the spec want a `RangeError`? I understand there is an extra clause in that there was no initial value either.

Thoughts?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/maraisr/observable/pull/185.html" title="Last updated on Dec 9, 2024, 11:08 AM UTC (fffc550)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/185/e1d9685...maraisr:fffc550.html" title="Last updated on Dec 9, 2024, 11:08 AM UTC (fffc550)">Diff</a>